### PR TITLE
Support multiple devices

### DIFF
--- a/luxafor-linux.py
+++ b/luxafor-linux.py
@@ -4,8 +4,6 @@ import usb.util
 import sys
 import argparse
 
-from itertools import repeat
-
 DEVICES = []
 ACTION = None
 LED = None
@@ -108,10 +106,9 @@ def writeValue(values):
         doWriteValue(flag, values)
 
 def doWriteValue(target, values):
-
     # Run it twice to ensure it works.
-    for _ in repeat(None, 2): 
-        target.write(1, values)
+    target.write(1, values)
+    target.write(1, values)
 
 def setPattern():
     writeValue( [6,PATTERN,REPEAT,0,0,0,0] )


### PR DESCRIPTION
I own more than 1 flag device (the standard Flag, and the Bluetooth Flag). They both have the same product ids.

This just adds loops/lists to the mix, and applies the same code to every matching device. Tested with Flag and Bluetooth devices.

Note: Patterns are buggy on the bluetooth device.