### PR TITLE
Python3 adjustment, code is running smoothly

### DIFF
--- a/luxafor-linux.py
+++ b/luxafor-linux.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3.8
 import usb.core
 import usb.util
 import sys
@@ -92,7 +92,7 @@ def setupDevices():
     for flag in DEVICES:
         try:
             flag.detach_kernel_driver(0)
-        except Exception, e:
+        except Exception:
             pass
      
         flag.set_configuration()

--- a/luxafor-linux.py
+++ b/luxafor-linux.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3.8
+#!/usr/bin/env python
 import usb.core
 import usb.util
 import sys

--- a/readme.md
+++ b/readme.md
@@ -7,6 +7,8 @@ Any and all improvements welcome and appreciated.
 Credit to gist by [dave-irvine](https://gist.github.com/dave-irvine/dbec2584e7508cbfc79e) for pyusb code.
 
 ## Requirements
+<!-- Thank you dave-irvine for pioneering the USB connection -->
+<!-- Thank YOU vmitchell85 for this beautiful little tool -->
 
 ### Linux
 
@@ -23,7 +25,7 @@ Credit to gist by [dave-irvine](https://gist.github.com/dave-irvine/dbec2584e750
 
 ## Confirmed Working Operating Systems
 - Windows 10
-- Ubuntu 15.10/17.10/18.10
+- Ubuntu 15.10/17.10/18.10/20.04
 
 ## Known/Possible Issues
 


### PR DESCRIPTION
I just received a Luxafor Bluetooth.  It is now running on my Ubuntu 20.04 system on Python 3.8
All that was needed for the Python2.7 -> Python3 adaptation was removing the ", e" from the Exception catch.